### PR TITLE
Groovy Gradle has different maven repository decl

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,9 @@ pluginManagement {
   repositories {
     gradlePluginPortal()
     maven("https://repo.papermc.io/repository/maven-public/")
+    
+    // When you're using groovy gradle dsl, the above line should be replaced with:
+    // maven { url = "https://repo.papermc.io/repository/maven-public/" }
   }
 }
 


### PR DESCRIPTION
It's just polite to notify the newbie developers who are just copy-pasting the code. 